### PR TITLE
Add navigation between menu, game, and settings screens

### DIFF
--- a/app/src/main/kotlin/com/github/a2kaido/go/android/navigation/NavigationRoutes.kt
+++ b/app/src/main/kotlin/com/github/a2kaido/go/android/navigation/NavigationRoutes.kt
@@ -1,0 +1,13 @@
+package com.github.a2kaido.go.android.navigation
+
+sealed class NavigationRoutes(val route: String) {
+    data object MainMenu : NavigationRoutes("main_menu")
+    data object GameSetup : NavigationRoutes("game_setup")
+    data object Game : NavigationRoutes("game")
+    data object Settings : NavigationRoutes("settings")
+    data object GameOver : NavigationRoutes("game_over/{winner}/{score}") {
+        fun createRoute(winner: String, score: String): String {
+            return "game_over/$winner/$score"
+        }
+    }
+}

--- a/app/src/main/kotlin/com/github/a2kaido/go/android/ui/screens/GameOverScreen.kt
+++ b/app/src/main/kotlin/com/github/a2kaido/go/android/ui/screens/GameOverScreen.kt
@@ -1,0 +1,111 @@
+package com.github.a2kaido.go.android.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun GameOverScreen(
+    winner: String,
+    score: String,
+    onRematch: () -> Unit,
+    onBackToMenu: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp),
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "Game Over",
+                    fontSize = 28.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(bottom = 24.dp)
+                )
+                
+                Text(
+                    text = "Winner",
+                    fontSize = 16.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                
+                Text(
+                    text = winner,
+                    fontSize = 32.sp,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(bottom = 24.dp)
+                )
+                
+                if (score.isNotBlank()) {
+                    Text(
+                        text = "Final Score",
+                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                    
+                    Text(
+                        text = score,
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Medium,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(bottom = 32.dp)
+                    )
+                }
+            }
+        }
+        
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Button(
+                onClick = onRematch,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+            ) {
+                Text(
+                    text = "Rematch",
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            OutlinedButton(
+                onClick = onBackToMenu,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+            ) {
+                Text(
+                    text = "Back to Menu",
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/github/a2kaido/go/android/ui/screens/GameSetupScreen.kt
+++ b/app/src/main/kotlin/com/github/a2kaido/go/android/ui/screens/GameSetupScreen.kt
@@ -1,0 +1,244 @@
+package com.github.a2kaido.go.android.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun GameSetupScreen(
+    onStartGame: (boardSize: Int, playerType: PlayerType, handicap: Int) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var selectedBoardSize by remember { mutableIntStateOf(9) }
+    var selectedPlayerType by remember { mutableStateOf(PlayerType.HUMAN_VS_AI) }
+    var selectedHandicap by remember { mutableIntStateOf(0) }
+    
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Game Setup",
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 32.dp)
+        )
+        
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 24.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text(
+                    text = "Board Size",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                
+                Column(modifier = Modifier.selectableGroup()) {
+                    BoardSizeOption(
+                        size = 9,
+                        description = "9×9 (Beginner)",
+                        selected = selectedBoardSize == 9,
+                        onSelect = { selectedBoardSize = 9 }
+                    )
+                    BoardSizeOption(
+                        size = 13,
+                        description = "13×13 (Intermediate)",
+                        selected = selectedBoardSize == 13,
+                        onSelect = { selectedBoardSize = 13 }
+                    )
+                    BoardSizeOption(
+                        size = 19,
+                        description = "19×19 (Standard)",
+                        selected = selectedBoardSize == 19,
+                        onSelect = { selectedBoardSize = 19 }
+                    )
+                }
+            }
+        }
+        
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 24.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text(
+                    text = "Player Type",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                
+                Column(modifier = Modifier.selectableGroup()) {
+                    PlayerTypeOption(
+                        type = PlayerType.HUMAN_VS_AI,
+                        description = "Human vs AI",
+                        selected = selectedPlayerType == PlayerType.HUMAN_VS_AI,
+                        onSelect = { selectedPlayerType = PlayerType.HUMAN_VS_AI }
+                    )
+                    PlayerTypeOption(
+                        type = PlayerType.HUMAN_VS_HUMAN,
+                        description = "Human vs Human",
+                        selected = selectedPlayerType == PlayerType.HUMAN_VS_HUMAN,
+                        onSelect = { selectedPlayerType = PlayerType.HUMAN_VS_HUMAN }
+                    )
+                    PlayerTypeOption(
+                        type = PlayerType.AI_VS_AI,
+                        description = "AI vs AI",
+                        selected = selectedPlayerType == PlayerType.AI_VS_AI,
+                        onSelect = { selectedPlayerType = PlayerType.AI_VS_AI }
+                    )
+                }
+            }
+        }
+        
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text(
+                    text = "Handicap",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(text = "Stones: $selectedHandicap")
+                    
+                    Row {
+                        OutlinedButton(
+                            onClick = { if (selectedHandicap > 0) selectedHandicap-- },
+                            modifier = Modifier.size(40.dp),
+                            contentPadding = PaddingValues(0.dp)
+                        ) {
+                            Text("-")
+                        }
+                        
+                        Spacer(modifier = Modifier.width(16.dp))
+                        
+                        OutlinedButton(
+                            onClick = { if (selectedHandicap < 9) selectedHandicap++ },
+                            modifier = Modifier.size(40.dp),
+                            contentPadding = PaddingValues(0.dp)
+                        ) {
+                            Text("+")
+                        }
+                    }
+                }
+            }
+        }
+        
+        Spacer(modifier = Modifier.weight(1f))
+        
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            OutlinedButton(
+                onClick = onBack,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(48.dp)
+            ) {
+                Text("Back")
+            }
+            
+            Button(
+                onClick = { onStartGame(selectedBoardSize, selectedPlayerType, selectedHandicap) },
+                modifier = Modifier
+                    .weight(1f)
+                    .height(48.dp)
+            ) {
+                Text("Start Game")
+            }
+        }
+    }
+}
+
+@Composable
+private fun BoardSizeOption(
+    size: Int,
+    description: String,
+    selected: Boolean,
+    onSelect: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                onClick = onSelect
+            )
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        RadioButton(
+            selected = selected,
+            onClick = onSelect
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(text = description)
+    }
+}
+
+@Composable
+private fun PlayerTypeOption(
+    type: PlayerType,
+    description: String,
+    selected: Boolean,
+    onSelect: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                onClick = onSelect
+            )
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        RadioButton(
+            selected = selected,
+            onClick = onSelect
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(text = description)
+    }
+}
+
+enum class PlayerType {
+    HUMAN_VS_AI,
+    HUMAN_VS_HUMAN,
+    AI_VS_AI
+}

--- a/app/src/main/kotlin/com/github/a2kaido/go/android/ui/screens/MainMenuScreen.kt
+++ b/app/src/main/kotlin/com/github/a2kaido/go/android/ui/screens/MainMenuScreen.kt
@@ -1,0 +1,95 @@
+package com.github.a2kaido.go.android.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun MainMenuScreen(
+    onNewGame: () -> Unit,
+    onContinueGame: () -> Unit,
+    onSettings: () -> Unit,
+    onAbout: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Go",
+            fontSize = 48.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = 48.dp)
+        )
+        
+        Spacer(modifier = Modifier.height(32.dp))
+        
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Button(
+                onClick = onNewGame,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+            ) {
+                Text(
+                    text = "New Game",
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            Button(
+                onClick = onContinueGame,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+            ) {
+                Text(
+                    text = "Continue Game",
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            OutlinedButton(
+                onClick = onSettings,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+            ) {
+                Text(
+                    text = "Settings",
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            
+            OutlinedButton(
+                onClick = onAbout,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+            ) {
+                Text(
+                    text = "About",
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/github/a2kaido/go/android/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/github/a2kaido/go/android/ui/screens/SettingsScreen.kt
@@ -1,0 +1,217 @@
+package com.github.a2kaido.go.android.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun SettingsScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var selectedTheme by remember { mutableStateOf(Theme.SYSTEM) }
+    var soundEnabled by remember { mutableStateOf(true) }
+    var hapticFeedbackEnabled by remember { mutableStateOf(true) }
+    var showCoordinates by remember { mutableStateOf(false) }
+    
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp)
+    ) {
+        Text(
+            text = "Settings",
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 32.dp)
+        )
+        
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 24.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text(
+                    text = "Appearance",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                
+                Text(
+                    text = "Theme",
+                    fontSize = 16.sp,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                
+                Column(modifier = Modifier.selectableGroup()) {
+                    ThemeOption(
+                        theme = Theme.LIGHT,
+                        description = "Light",
+                        selected = selectedTheme == Theme.LIGHT,
+                        onSelect = { selectedTheme = Theme.LIGHT }
+                    )
+                    ThemeOption(
+                        theme = Theme.DARK,
+                        description = "Dark",
+                        selected = selectedTheme == Theme.DARK,
+                        onSelect = { selectedTheme = Theme.DARK }
+                    )
+                    ThemeOption(
+                        theme = Theme.SYSTEM,
+                        description = "System Default",
+                        selected = selectedTheme == Theme.SYSTEM,
+                        onSelect = { selectedTheme = Theme.SYSTEM }
+                    )
+                }
+            }
+        }
+        
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 24.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text(
+                    text = "Audio & Haptics",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                
+                SettingsSwitchItem(
+                    title = "Sound Effects",
+                    description = "Play sound effects during gameplay",
+                    checked = soundEnabled,
+                    onCheckedChange = { soundEnabled = it }
+                )
+                
+                SettingsSwitchItem(
+                    title = "Haptic Feedback",
+                    description = "Vibrate on stone placement",
+                    checked = hapticFeedbackEnabled,
+                    onCheckedChange = { hapticFeedbackEnabled = it }
+                )
+            }
+        }
+        
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text(
+                    text = "Gameplay",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                
+                SettingsSwitchItem(
+                    title = "Show Coordinates",
+                    description = "Display board coordinates (A-T, 1-19)",
+                    checked = showCoordinates,
+                    onCheckedChange = { showCoordinates = it }
+                )
+            }
+        }
+        
+        Spacer(modifier = Modifier.weight(1f))
+        
+        Button(
+            onClick = onBack,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp)
+        ) {
+            Text("Back to Menu")
+        }
+    }
+}
+
+@Composable
+private fun ThemeOption(
+    theme: Theme,
+    description: String,
+    selected: Boolean,
+    onSelect: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                onClick = onSelect
+            )
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        RadioButton(
+            selected = selected,
+            onClick = onSelect
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(text = description)
+    }
+}
+
+@Composable
+private fun SettingsSwitchItem(
+    title: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = title,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = description,
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange
+        )
+    }
+}
+
+enum class Theme {
+    LIGHT,
+    DARK,
+    SYSTEM
+}


### PR DESCRIPTION
## Summary
- Implement comprehensive navigation system using Navigation Compose
- Add screen hierarchy: Main Menu → Game Setup → Game → Game Over
- Include Settings screen with theme, audio, and gameplay preferences
- Support proper back navigation and navigation state management

## Test plan
- [x] Build completes successfully without errors
- [ ] Manual testing of navigation flow between all screens
- [ ] Test game setup options integration with game state
- [ ] Verify settings persistence and theme changes
- [ ] Test game over screen navigation and rematch functionality
- [ ] Verify deep linking and back navigation behavior

🤖 Generated with [Claude Code](https://claude.ai/code)