### PR TITLE
Implement touch input handling for stone placement

### DIFF
--- a/app/src/main/kotlin/com/github/a2kaido/go/android/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/a2kaido/go/android/MainActivity.kt
@@ -70,6 +70,10 @@ class MainActivity : ComponentActivity() {
                             GoGameScreen(
                                 uiState = uiState,
                                 onCellClick = gameViewModel::onCellClick,
+                                onCellHover = gameViewModel::onCellHover,
+                                onHoverExit = gameViewModel::onHoverExit,
+                                onZoomPanChange = gameViewModel::onZoomPanChange,
+                                onResetZoomPan = gameViewModel::resetZoomPan,
                                 onPassClick = gameViewModel::onPassClick,
                                 onResignClick = gameViewModel::onResignClick,
                                 onUndoClick = gameViewModel::onUndoClick,
@@ -126,6 +130,10 @@ class MainActivity : ComponentActivity() {
 fun GoGameScreen(
     uiState: GameUiState,
     onCellClick: (Int, Int) -> Unit,
+    onCellHover: (Int, Int) -> Unit = { _, _ -> },
+    onHoverExit: () -> Unit = {},
+    onZoomPanChange: (Float, androidx.compose.ui.geometry.Offset) -> Unit = { _, _ -> },
+    onResetZoomPan: () -> Unit = {},
     onPassClick: () -> Unit,
     onResignClick: () -> Unit,
     onUndoClick: () -> Unit,
@@ -199,13 +207,31 @@ fun GoGameScreen(
             boardSize = uiState.boardSize,
             lastMove = uiState.lastMove,
             onCellClick = onCellClick,
+            onCellHover = onCellHover,
+            onHoverExit = onHoverExit,
             enabled = !uiState.isThinking && uiState.gameStatus is GameStatus.ONGOING,
+            currentPlayer = uiState.currentPlayer,
+            hoverPoint = uiState.hoverPoint,
+            invalidMoveAttempt = uiState.invalidMoveAttempt,
+            onZoomPanChange = onZoomPanChange,
+            zoomScale = uiState.zoomScale,
+            panOffset = uiState.panOffset,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
         )
         
         Spacer(modifier = Modifier.height(16.dp))
+        
+        // Reset zoom button (only show when zoomed)
+        if (uiState.zoomScale > 1f && uiState.boardSize > 9) {
+            Button(
+                onClick = onResetZoomPan,
+                modifier = Modifier.padding(bottom = 8.dp)
+            ) {
+                Text("Reset Zoom")
+            }
+        }
         
         // Game controls
         Row(

--- a/app/src/main/kotlin/com/github/a2kaido/go/android/ui/GameUiState.kt
+++ b/app/src/main/kotlin/com/github/a2kaido/go/android/ui/GameUiState.kt
@@ -3,6 +3,8 @@ package com.github.a2kaido.go.android.ui
 import com.github.a2kaido.go.model.Player
 import com.github.a2kaido.go.model.Point
 
+import androidx.compose.ui.geometry.Offset
+
 data class GameUiState(
     val boardSize: Int = 9,
     val boardState: Map<Point, Player> = emptyMap(),
@@ -13,7 +15,11 @@ data class GameUiState(
     val gameStatus: GameStatus = GameStatus.ONGOING,
     val isThinking: Boolean = false,
     val canUndo: Boolean = false,
-    val canRedo: Boolean = false
+    val canRedo: Boolean = false,
+    val hoverPoint: Point? = null,
+    val invalidMoveAttempt: Point? = null,
+    val zoomScale: Float = 1f,
+    val panOffset: Offset = Offset.Zero
 )
 
 sealed class GameStatus {


### PR DESCRIPTION
## Summary
- Add interactive touch controls for placing stones on the Go board
- Implement ghost stone preview that follows finger movement
- Add pinch-to-zoom and pan gestures for larger boards (13x13, 19x19)
- Provide visual feedback for invalid move attempts

## Changes
### Touch Interaction
- **Move Preview**: Semi-transparent "ghost" stones appear when hovering over valid positions
- **Drag Support**: Continuous preview updates while dragging across the board
- **Coordinate Conversion**: Accurate touch-to-board coordinate mapping with zoom/pan compensation

### Visual Feedback
- **Ghost Stones**: 50% opacity preview stones show where the move will be placed
- **Invalid Move Indicator**: Red X briefly appears when attempting invalid moves (occupied positions, ko rule violations)
- **Last Move Marker**: Circle indicator on the most recently placed stone

### Gesture Support
- **Pinch to Zoom**: Scale board up to 3x for larger boards (enabled only for 13x13 and 19x19)
- **Pan Navigation**: Drag to navigate when zoomed in
- **Reset Zoom Button**: Quick reset to default view when zoomed

### State Management
- Added `hoverPoint`, `invalidMoveAttempt`, `zoomScale`, and `panOffset` to `GameUiState`
- New ViewModel methods: `onCellHover`, `onHoverExit`, `onZoomPanChange`, `resetZoomPan`
- Proper state preservation during game updates

## Testing
- Built successfully with `./gradlew :app:build`
- Touch interactions properly disabled during AI thinking
- Zoom/pan gestures only enabled for larger board sizes
- Invalid move feedback works for occupied positions and ko rule violations

## Dependencies
This implementation builds upon:
- #2 (Board UI) ✅
- #3 (ViewModel) ✅

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)