### PR TITLE
Remove audio and haptics settings from Settings screen

### DIFF
--- a/app/src/main/kotlin/com/github/a2kaido/go/android/feedback/FeedbackManager.kt
+++ b/app/src/main/kotlin/com/github/a2kaido/go/android/feedback/FeedbackManager.kt
@@ -55,29 +55,6 @@ class FeedbackManager(context: Context, scope: CoroutineScope) {
         hapticManager.performHapticFeedback(HapticFeedbackType.BUTTON_CLICK)
     }
     
-    // Settings methods
-    fun setSoundEnabled(enabled: Boolean) {
-        audioManager.setSoundEnabled(enabled)
-    }
-    
-    fun setHapticEnabled(enabled: Boolean) {
-        hapticManager.setHapticEnabled(enabled)
-    }
-    
-    fun setMasterVolume(volume: Float) {
-        audioManager.setMasterVolume(volume)
-    }
-    
-    fun setHapticIntensity(intensity: HapticIntensity) {
-        hapticManager.setHapticIntensity(intensity)
-    }
-    
-    // Getters
-    fun isSoundEnabled(): Boolean = audioManager.isSoundEnabled()
-    fun isHapticEnabled(): Boolean = hapticManager.isHapticEnabled()
-    fun getMasterVolume(): Float = audioManager.getMasterVolume()
-    fun getHapticIntensity(): HapticIntensity = hapticManager.getHapticIntensity()
-    fun isHapticSupported(): Boolean = hapticManager.isHapticSupported()
     
     fun release() {
         audioManager.release()

--- a/app/src/main/kotlin/com/github/a2kaido/go/android/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/github/a2kaido/go/android/ui/screens/SettingsScreen.kt
@@ -12,21 +12,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.github.a2kaido.go.android.haptic.HapticIntensity
 
 @Composable
 fun SettingsScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
-    soundEnabled: Boolean = true,
-    onSoundEnabledChange: (Boolean) -> Unit = {},
-    hapticEnabled: Boolean = true,
-    onHapticEnabledChange: (Boolean) -> Unit = {},
-    masterVolume: Float = 1.0f,
-    onMasterVolumeChange: (Float) -> Unit = {},
-    hapticIntensity: HapticIntensity = HapticIntensity.MEDIUM,
-    onHapticIntensityChange: (HapticIntensity) -> Unit = {},
-    hapticSupported: Boolean = true
 ) {
     var selectedTheme by remember { mutableStateOf(Theme.SYSTEM) }
     var showCoordinates by remember { mutableStateOf(false) }
@@ -83,72 +73,6 @@ fun SettingsScreen(
                         description = "System Default",
                         selected = selectedTheme == Theme.SYSTEM,
                         onSelect = { selectedTheme = Theme.SYSTEM }
-                    )
-                }
-            }
-        }
-        
-        Card(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 24.dp)
-        ) {
-            Column(
-                modifier = Modifier.padding(16.dp)
-            ) {
-                Text(
-                    text = "Audio & Haptics",
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.Medium,
-                    modifier = Modifier.padding(bottom = 16.dp)
-                )
-                
-                SettingsSwitchItem(
-                    title = "Sound Effects",
-                    description = "Play sound effects during gameplay",
-                    checked = soundEnabled,
-                    onCheckedChange = onSoundEnabledChange
-                )
-                
-                if (soundEnabled) {
-                    SettingsSliderItem(
-                        title = "Master Volume",
-                        description = "Adjust overall sound volume",
-                        value = masterVolume,
-                        onValueChange = onMasterVolumeChange
-                    )
-                }
-                
-                if (hapticSupported) {
-                    SettingsSwitchItem(
-                        title = "Haptic Feedback",
-                        description = "Vibrate on stone placement",
-                        checked = hapticEnabled,
-                        onCheckedChange = onHapticEnabledChange
-                    )
-                    
-                    if (hapticEnabled) {
-                        SettingsDropdownItem(
-                            title = "Haptic Intensity",
-                            description = "Adjust vibration strength",
-                            selectedValue = hapticIntensity,
-                            options = HapticIntensity.values().toList(),
-                            onValueChange = onHapticIntensityChange,
-                            optionLabel = { intensity ->
-                                when (intensity) {
-                                    HapticIntensity.LIGHT -> "Light"
-                                    HapticIntensity.MEDIUM -> "Medium"
-                                    HapticIntensity.STRONG -> "Strong"
-                                }
-                            }
-                        )
-                    }
-                } else {
-                    Text(
-                        text = "Haptic feedback not supported on this device",
-                        fontSize = 14.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(vertical = 8.dp)
                     )
                 }
             }

--- a/app/src/main/kotlin/com/github/a2kaido/go/android/viewmodel/GameViewModel.kt
+++ b/app/src/main/kotlin/com/github/a2kaido/go/android/viewmodel/GameViewModel.kt
@@ -509,28 +509,6 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         return gameState.board.grid.values.count { it.color == player }.toFloat()
     }
 
-    // Feedback settings methods
-    fun setSoundEnabled(enabled: Boolean) {
-        feedbackManager.setSoundEnabled(enabled)
-    }
-    
-    fun setHapticEnabled(enabled: Boolean) {
-        feedbackManager.setHapticEnabled(enabled)
-    }
-    
-    fun setMasterVolume(volume: Float) {
-        feedbackManager.setMasterVolume(volume)
-    }
-    
-    fun setHapticIntensity(intensity: com.github.a2kaido.go.android.haptic.HapticIntensity) {
-        feedbackManager.setHapticIntensity(intensity)
-    }
-    
-    fun isSoundEnabled(): Boolean = feedbackManager.isSoundEnabled()
-    fun isHapticEnabled(): Boolean = feedbackManager.isHapticEnabled()
-    fun getMasterVolume(): Float = feedbackManager.getMasterVolume()
-    fun getHapticIntensity(): com.github.a2kaido.go.android.haptic.HapticIntensity = feedbackManager.getHapticIntensity()
-    fun isHapticSupported(): Boolean = feedbackManager.isHapticSupported()
 
     override fun onCleared() {
         super.onCleared()


### PR DESCRIPTION
## Summary
- Remove audio and haptics configuration options from the Settings screen
- Simplify Settings UI to only include Appearance and Gameplay sections
- Remove related parameter handling and methods while preserving core feedback functionality

## Test plan
- [ ] Settings screen loads without audio/haptic options
- [ ] App builds and runs successfully
- [ ] Core audio/haptic feedback still works during gameplay

🤖 Generated with [Claude Code](https://claude.ai/code)